### PR TITLE
Fix models to support pydantic orm_mode

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/item.py
@@ -6,6 +6,9 @@ class ItemBase(BaseModel):
     title: str = None
     description: str = None
 
+    class Config:
+        orm_mode = True
+
 
 # Properties to receive on item creation
 class ItemCreate(ItemBase):

--- a/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/models/user.py
@@ -10,6 +10,9 @@ class UserBase(BaseModel):
     is_superuser: Optional[bool] = False
     full_name: Optional[str] = None
 
+    class Config:
+        orm_mode = True
+
 
 class UserBaseInDB(UserBase):
     id: int = None


### PR DESCRIPTION
See GitHub PR 43
tiangolo/full-stack-fastapi-postgresql#43
See GitHub issue 72
tiangolo/full-stack-fastapi-postgresql#72

When viewing the user profile, name and email weren't showing up.

Docker Compose logs showed a pydantic error:
https://pydantic-docs.helpmanual.io/

```
backend_1        | pydantic.error_wrappers.ValidationError: 1 validation
                   error for User
backend_1        | response -> 0
backend_1        |   value is not a valid dict (type=type_error.dict)
```

Pydantic orm_mode is needed. This commit will update the database models
to use pydantic orm_mode, with cleaner syntax than the fix suggested in
issue #72 (by adding class Config directly to the base class).